### PR TITLE
Fix for stop times with whitespace

### DIFF
--- a/src/GTFS/GTFSReader.cs
+++ b/src/GTFS/GTFSReader.cs
@@ -2322,10 +2322,11 @@ namespace GTFS
         /// <returns></returns>
         protected virtual string CleanFieldValue(string value)
         {
+            value = value.Trim();
+
             if (!_strict)
             {
                 // no cleaning when strict!
-                value = value.Trim();
                 if (value != null && value.Length > 0)
                 {
                     // test some stuff.


### PR DESCRIPTION
Allowed CleanFieldValue to always trim the field even if in strict mode. This prevents errors when parsing times in strict mode that contain whitesapce